### PR TITLE
style: add word break rules to text layout

### DIFF
--- a/frontend/src/components/layout/textLayout/textLayout.module.css
+++ b/frontend/src/components/layout/textLayout/textLayout.module.css
@@ -1,5 +1,8 @@
 .container {
   font-family: var(--chapter-body-font);
+  /* Handle long unbreakable words like '-----------------------' */
+  word-break: break-word;
+  overflow-wrap: break-word;
   padding-block: 0.5rem;
 
   & a {


### PR DESCRIPTION
Closes #50 

**What's Changed?**
- Force word breaks to allow the browser to be resized smaller.